### PR TITLE
Fix minor typo

### DIFF
--- a/lib/Bootylicious/Plugin/BootyConfig.pm
+++ b/lib/Bootylicious/Plugin/BootyConfig.pm
@@ -179,7 +179,7 @@ sub _default {
             'later'               => 'Later',
             'earlier'             => 'Earlier',
             'not-found' => 'The page you are looking for was not found',
-            'error'     => 'Internal error occuried :('
+            'error'     => 'Internal error occurred :('
         },
         template_handler => 'ep',
 


### PR DESCRIPTION
500 error said "Internal error occuried :(". changed it to "Internal error occurred :(".
